### PR TITLE
READMEにDB設計を記載

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*

--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
README.mdにデータベース設計を記載する。
groups_usersテーブル、アソシエーションを追記。

# Why
グループとユーザーのテーブルを関連付けさせるため。