### PR TITLE
ChatSpaceの自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,4 +65,47 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     });
   })
+
+  //自動更新用の関数定義
+  let reloadMessages = function () {
+
+      //ブラウザに表示されている最後のメッセージからidを取得して、変数に代入
+      let last_message_id = $('.message:last').data("message-id");
+
+      //ajaxの処理   
+      $.ajax({
+        //今回はapiのmessagesコントローラーに飛ばす
+        url: "api/messages",
+        //HTTP＿メソッド
+        type: 'get',
+        //データはjson型で
+        dataType: 'json',
+        //キーを自分で決め（今回はｌａｓｔ_id)そこに先ほど定義したlast_message_idを代入。これはコントローラーのparamsで取得される。
+        data: {last_id: last_message_id} 
+      })
+
+    //doneの処理
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するhtmlの入れ物をつくる
+        let insertHTML = '';
+        //取得したメッセージたちをEach文で分解
+        messages.forEach(function (message) {
+        //htmlを作り出して、それを変数に代入(作り出す処理は非同期の時に作った)
+        insertHTML = buildHTML(message);
+        });
+        //変数に代入されたhtmlをmessagesクラスにぶち込む
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+  
+    //failの処理
+    .fail(function() {
+      alert('自動更新に失敗しました');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 2000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+    #今いるグループの情報をparamsによって取得し変数@groupに代入
+    @group = Group.find(params[:group_id]) 
+
+    #グループ内のメッセージでlast_idよりも大きいidのメッセージがないかを探してきてそれらを@messageに代入
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,5 @@
-.message
+//メッセージ全体にidを付与。  ※ #{message.id}はjbuilderファイルで定義している
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id


### PR DESCRIPTION
## What
[![Screenshot from Gyazo](https://gyazo.com/3aad65cf5e752c8731c5bcbc732aef5a/raw)](https://gyazo.com/3aad65cf5e752c8731c5bcbc732aef5a)

メッセージを更新するためのアクションやコントローラーを用意し、JSファイルを編集して自動更新が行われるようにした。

■message.js
```
if (document.location.href.match(/\/groups\/\d+\/messages/)) {
    setInterval(reloadMessages, 2000);
  }
```
2秒おき(gif対応)にajax通信を行う関数が発動するように設定。

## Why
ログインユーザーが自分以外のユーザーがチャットをした際に、リロードすることなく最新のチャットを見てすぐにレスポンスをするができるようにするため。